### PR TITLE
Add more flexible types

### DIFF
--- a/models/index.ts
+++ b/models/index.ts
@@ -35,19 +35,27 @@ export type cohereParameters = | generate | similarity | embed | chooseBest | li
 
 /* -- responses -- */
 export interface text {
-  text: string
+  text: string,
+  token_likelihoods?: {
+    token: string,
+    likelihood?: number
+  },
+  [key: string]: any,
 }
 
 export interface similarities {
-  similarities: number[]
+  similarities: number[],
+  [key: string]: any
 }
 
 export interface embeddings {
   embeddings: number[][]
+  [key: string]: any,
 }
 
 export interface likelihoods {
   likelihoods: number[]
+  [key: string]: any,
 }
 
 export interface token_likelihoods {
@@ -56,10 +64,12 @@ export interface token_likelihoods {
     token: string,
     likelihood?: number
   }
+  [key: string]: any,
 }
 
 export interface error {
   message ?: string
+  [key: string]: any,
 }
 
 export type responseBody = text | similarities | embeddings | likelihoods | token_likelihoods | error;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohere-ai",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A Node.js SDK with TypeScript support for the Cohere API.",
   "homepage": "https://docs.cohere.ai",
   "main": "index.js",


### PR DESCRIPTION
The sdk shouldn't break if a parameter changes or is added. This adds Indexable types to the response objects in typescript to allow any number of parameters in the response. Ideally the declarations should be kept up to date, but in the worst case scenario the types shouldn't cause problems with regards to unexpected changes. 