### PR TITLE
support multi gen and remove client err handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@ npm install cohere-ai
 const cohere = require('cohere-ai');
 ```
 
-### Initialize the library.
+### Initialize the library using the latest version of the API.
 ```js
 cohere.init('YOUR_API_KEY');
+```
+### Or optionally initialize with a specific version. (Learn about versions [here](https://docs.cohere.ai/versions-reference).)
+```js
+cohere.init('YOUR_API_KEY', '2021-11-08');
 ```
 
 ### Call the endpoint function you'd like to hit to interact with the Cohere API.

--- a/cohere.ts
+++ b/cohere.ts
@@ -10,7 +10,7 @@ enum ENDPOINT {
 }
 
 interface CohereService {
-  init(key: string): void;
+  init(key: string, version?: string): void;
   generate(
     model: string,
     config: models.generate
@@ -34,8 +34,8 @@ interface CohereService {
 }
 
 class Cohere implements CohereService {
-  public init(key: string): void {
-    API.init(key);
+  public init(key: string, version?: string): void {
+    API.init(key, version);
   }
 
   private makeRequest(

--- a/models/index.ts
+++ b/models/index.ts
@@ -7,6 +7,7 @@ export interface cohereResponse <T>{
 export interface generate {
   prompt: string;
   max_tokens: number;
+  num_generations?: number;
   temperature: number;
   k?: number;
   p?: number;

--- a/models/index.ts
+++ b/models/index.ts
@@ -49,11 +49,11 @@ export interface text {
 
 export interface similarities {
   similarities: number[],
-  [key: string]: any
+  [key: string]: any,
 }
 
 export interface embeddings {
-  embeddings: number[][]
+  embeddings: number[][],
   [key: string]: any,
 }
 
@@ -68,13 +68,13 @@ export interface token_likelihoods {
   likelihood: number,
   token_likelihoods: {
     token: string,
-    likelihood?: number
+    likelihood?: number,
   }
   [key: string]: any,
 }
 
 export interface error {
-  message ?: string
+  message ?: string,
   [key: string]: any,
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cohere-ai",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cohere-ai",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.2.18",
@@ -25,7 +25,7 @@
         "ts-node": "^9.1.1",
         "typescript": "^4.2.4",
         "webpack": "^5.37.0",
-        "webpack-cli": "^4.7.0"
+        "webpack-cli": "^4.9.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -752,9 +752,9 @@
       }
     },
     "node_modules/@webpack-cli/configtest": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.3.tgz",
-      "integrity": "sha512-WQs0ep98FXX2XBAfQpRbY0Ma6ADw8JR6xoIkaIiJIzClGOMqVRvPCWqndTxf28DgFopWan0EKtHtg/5W1h0Zkw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
+      "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
       "dev": true,
       "peerDependencies": {
         "webpack": "4.x.x || 5.x.x",
@@ -762,9 +762,9 @@
       }
     },
     "node_modules/@webpack-cli/info": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.2.4.tgz",
-      "integrity": "sha512-ogE2T4+pLhTTPS/8MM3IjHn0IYplKM4HbVNMCWA9N4NrdPzunwenpCsqKEXyejMfRu6K8mhauIPYf8ZxWG5O6g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
+      "integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
       "dev": true,
       "dependencies": {
         "envinfo": "^7.7.3"
@@ -774,9 +774,9 @@
       }
     },
     "node_modules/@webpack-cli/serve": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.4.0.tgz",
-      "integrity": "sha512-xgT/HqJ+uLWGX+Mzufusl3cgjAcnqYYskaB7o0vRcwOEfuu6hMzSILQpnIzFMGsTaeaX4Nnekl+6fadLbl1/Vg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
+      "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
       "dev": true,
       "peerDependencies": {
         "webpack-cli": "4.x.x"
@@ -4562,23 +4562,22 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.7.0.tgz",
-      "integrity": "sha512-7bKr9182/sGfjFm+xdZSwgQuFjgEcy0iCTIBxRUeteJ2Kr8/Wz0qNJX+jw60LU36jApt4nmMkep6+W5AKhok6g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
+      "integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
       "dev": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
-        "@webpack-cli/configtest": "^1.0.3",
-        "@webpack-cli/info": "^1.2.4",
-        "@webpack-cli/serve": "^1.4.0",
-        "colorette": "^1.2.1",
+        "@webpack-cli/configtest": "^1.1.0",
+        "@webpack-cli/info": "^1.4.0",
+        "@webpack-cli/serve": "^1.6.0",
+        "colorette": "^2.0.14",
         "commander": "^7.0.0",
         "execa": "^5.0.0",
         "fastest-levenshtein": "^1.0.12",
         "import-local": "^3.0.2",
         "interpret": "^2.2.0",
         "rechoir": "^0.7.0",
-        "v8-compile-cache": "^2.2.0",
         "webpack-merge": "^5.7.3"
       },
       "bin": {
@@ -4604,6 +4603,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/webpack-cli/node_modules/colorette": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+      "dev": true
     },
     "node_modules/webpack-cli/node_modules/commander": {
       "version": "7.2.0",
@@ -5456,25 +5461,25 @@
       }
     },
     "@webpack-cli/configtest": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.3.tgz",
-      "integrity": "sha512-WQs0ep98FXX2XBAfQpRbY0Ma6ADw8JR6xoIkaIiJIzClGOMqVRvPCWqndTxf28DgFopWan0EKtHtg/5W1h0Zkw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
+      "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
       "dev": true,
       "requires": {}
     },
     "@webpack-cli/info": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.2.4.tgz",
-      "integrity": "sha512-ogE2T4+pLhTTPS/8MM3IjHn0IYplKM4HbVNMCWA9N4NrdPzunwenpCsqKEXyejMfRu6K8mhauIPYf8ZxWG5O6g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
+      "integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
       "dev": true,
       "requires": {
         "envinfo": "^7.7.3"
       }
     },
     "@webpack-cli/serve": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.4.0.tgz",
-      "integrity": "sha512-xgT/HqJ+uLWGX+Mzufusl3cgjAcnqYYskaB7o0vRcwOEfuu6hMzSILQpnIzFMGsTaeaX4Nnekl+6fadLbl1/Vg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
+      "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
       "dev": true,
       "requires": {}
     },
@@ -8286,26 +8291,31 @@
       }
     },
     "webpack-cli": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.7.0.tgz",
-      "integrity": "sha512-7bKr9182/sGfjFm+xdZSwgQuFjgEcy0iCTIBxRUeteJ2Kr8/Wz0qNJX+jw60LU36jApt4nmMkep6+W5AKhok6g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
+      "integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
       "dev": true,
       "requires": {
         "@discoveryjs/json-ext": "^0.5.0",
-        "@webpack-cli/configtest": "^1.0.3",
-        "@webpack-cli/info": "^1.2.4",
-        "@webpack-cli/serve": "^1.4.0",
-        "colorette": "^1.2.1",
+        "@webpack-cli/configtest": "^1.1.0",
+        "@webpack-cli/info": "^1.4.0",
+        "@webpack-cli/serve": "^1.6.0",
+        "colorette": "^2.0.14",
         "commander": "^7.0.0",
         "execa": "^5.0.0",
         "fastest-levenshtein": "^1.0.12",
         "import-local": "^3.0.2",
         "interpret": "^2.2.0",
         "rechoir": "^0.7.0",
-        "v8-compile-cache": "^2.2.0",
         "webpack-merge": "^5.7.3"
       },
       "dependencies": {
+        "colorette": {
+          "version": "2.0.16",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+          "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+          "dev": true
+        },
         "commander": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cohere-ai",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cohere-ai",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.2.18",
@@ -852,62 +852,12 @@
       }
     },
     "node_modules/ansi-align": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
-      "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
       "dev": true,
       "dependencies": {
-        "string-width": "^3.0.0"
-      }
-    },
-    "node_modules/ansi-align/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ansi-align/node_modules/emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true
-    },
-    "node_modules/ansi-align/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ansi-align/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ansi-align/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "string-width": "^4.1.0"
       }
     },
     "node_modules/ansi-colors": {
@@ -920,9 +870,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -3537,9 +3487,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "node_modules/path-type": {
@@ -5534,52 +5484,12 @@
       "requires": {}
     },
     "ansi-align": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
-      "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
       "dev": true,
       "requires": {
-        "string-width": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
+        "string-width": "^4.1.0"
       }
     },
     "ansi-colors": {
@@ -5589,9 +5499,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -7554,9 +7464,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-type": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohere-ai",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A Node.js SDK with TypeScript support for the Cohere API.",
   "homepage": "https://docs.cohere.ai",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohere-ai",
-  "version": "1.0.8",
+  "version": "2.0.0",
   "description": "A Node.js SDK with TypeScript support for the Cohere API.",
   "homepage": "https://docs.cohere.ai",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "ts-node": "^9.1.1",
     "typescript": "^4.2.4",
     "webpack": "^5.37.0",
-    "webpack-cli": "^4.7.0"
+    "webpack-cli": "^4.9.1"
   }
 }

--- a/services/api_service.ts
+++ b/services/api_service.ts
@@ -50,7 +50,7 @@ class APIImpl implements APIService {
         res.on('end', () => {
           resolve({
             statusCode: res.statusCode,
-            body: JSON.parse(Buffer.concat(data).toString())
+            body: JSON.parse(Buffer.concat(data).toString()),
           })
         })
       })

--- a/services/api_service.ts
+++ b/services/api_service.ts
@@ -3,7 +3,7 @@ import { cohereResponse, cohereParameters, responseBody } from '../models';
 import errors from './error_service'
 
 interface APIService {
-  init(key: string): void;
+  init(key: string, version?: string): void;
   post(endpoint: string, data: cohereParameters): Promise<cohereResponse<responseBody>>;
 }
 
@@ -13,13 +13,19 @@ enum URL {
 
 class APIImpl implements APIService {
   private COHERE_API_KEY = '';
+  private COHERE_VERSION = ''; 
 
-  public init(key: string): void {
+  public init(key: string, version?: string): void {
     this.COHERE_API_KEY = key;
+
+    if (version === undefined) {
+      this.COHERE_VERSION = '2021-11-08'; // currently latest, update when we version better
+    } else {
+      this.COHERE_VERSION = version;
+    }
   }
 
   public async post(endpoint: string, data: cohereParameters): Promise<cohereResponse<responseBody>> {
-    if (!this.COHERE_API_KEY) return new Promise(resolve=> resolve(errors.specificError('API_KEY_MISSING', 403)));
     return new Promise((resolve, reject) => {
       try {
         // workaround for js projects that pass json strings.
@@ -34,6 +40,7 @@ class APIImpl implements APIService {
         headers: {
           'Content-Type': 'application/json',
           'Content-Length': reqData.length,
+          'Cohere-Version': this.COHERE_VERSION,
           'Authorization': `Bearer ${this.COHERE_API_KEY}`
         },
       }, (res) => {

--- a/services/error_service.ts
+++ b/services/error_service.ts
@@ -8,31 +8,15 @@ interface cohereError {
   };
   message?: string;
 }
-
+ 
 interface errorService {
-  specificError(error: keyof typeof ERROR_MSG, statusCode: number): cohereResponse<error>;
   handleError(error: cohereError): cohereResponse<error>;
 }
 
-enum ERROR_MSG {
-  GENERIC = "Whoops! Something went wrong with this request.",
-  API_KEY_MISSING = "Whoops! You need to provide an API key before making requests. Try cohere.init(YOUR_KEY).",
-  PARAMETERS_MISSING_OR_INVALID = "Uh oh. it looks like something is wrong with the parameters you provided."
-}
-
 class errorImpl implements errorService {
-  public specificError(error: keyof typeof ERROR_MSG, statusCode: number): cohereResponse<error> {
-    return {
-      statusCode,
-      body: {
-        message: ERROR_MSG[error]
-      }
-    }
-  }
-
   public handleError(error: cohereError): cohereResponse<error> {
     const status = error.response?.status || 500;
-    const message = error.response?.data?.message || error.message || ERROR_MSG.GENERIC;
+    const message = error.response?.data?.message || error.message;
     return {
       statusCode: status,
       body: {

--- a/services/error_service.ts
+++ b/services/error_service.ts
@@ -20,7 +20,7 @@ class errorImpl implements errorService {
     return {
       statusCode: status,
       body: {
-        message: message
+        message: message,
       }
     };
   }

--- a/test/choose-best.ts
+++ b/test/choose-best.ts
@@ -8,7 +8,7 @@ describe('The choose-best endpoint', () => {
   cohere.init(KEY);
   const options = ["book", "glasses", "dog"];
   before(async () => {
-    response = await cohere.chooseBest("large", {
+    response = await cohere.chooseBest("small", {
       query: "Carol picked up a book and walked to the kitchen. She set it down, picked up her glasses and left. This is in the kitchen now: ",
       options,
       mode: "APPEND_OPTION",

--- a/test/choose-best.ts
+++ b/test/choose-best.ts
@@ -11,7 +11,7 @@ describe('The choose-best endpoint', () => {
     response = await cohere.chooseBest("baseline-shrimp", {
       query: "Carol picked up a book and walked to the kitchen. She set it down, picked up her glasses and left. This is in the kitchen now: ",
       options,
-      mode: "APPEND_OPTION"
+      mode: "APPEND_OPTION",
     });
   });
   it('Should should have a statusCode of 200', () => {

--- a/test/embed.ts
+++ b/test/embed.ts
@@ -8,7 +8,7 @@ describe('The embed endpoint', () => {
   cohere.init(KEY);
   const texts = ["hello", "goodbye"];
   before(async () => {
-    response = await cohere.embed("large", { texts });
+    response = await cohere.embed("small", { texts });
   });
   it('Should should have a statusCode of 200', () => {
     expect(response).to.have.property('statusCode');

--- a/test/generate.ts
+++ b/test/generate.ts
@@ -23,7 +23,7 @@ cohere.init(KEY);
 describe('The generate endpoint successfully completes', () => {
   var response:any;
   before(async () => {
-    response = await cohere.generate("large", {
+    response = await cohere.generate("small", {
       prompt: "hello what is your name",
       max_tokens: 20,
       temperature: 1,
@@ -49,7 +49,7 @@ describe('The generate endpoint successfully completes', () => {
 describe('The generate endpoint successfully completes with multiple generations', () => {
   var response:any;
   before(async () => {
-    response = await cohere.generate("large", {
+    response = await cohere.generate("small", {
       prompt: "hello what is your name",
       max_tokens: 20,
       temperature: 1,

--- a/test/generate.ts
+++ b/test/generate.ts
@@ -20,7 +20,7 @@ const KEY:string = process.env.API_KEY || '';
 // });
 cohere.init(KEY);
 
-describe('The generate endpoint', () => {
+describe('The generate endpoint successfully completes', () => {
   var response:any;
   before(async () => {
     response = await cohere.generate("baseline-shrimp", {
@@ -35,12 +35,32 @@ describe('The generate endpoint', () => {
     expect(response).to.have.property('statusCode');
     expect(response.statusCode).to.equal(200);
   });
-  it('Should contain a body property that contains a text property', () => {
+  it('Should contain a body property that contains a generations array of length one that contains a text property', () => {
     expect(response).to.have.property('body');
-    expect(response.body).to.have.property('text');
+    expect(response.body).to.have.property('generations');
+    expect(response.body.generations).to.have.lengthOf(1);
+    expect(response.body.generations[0]).to.have.property('text');
   });
-  it('Should contain text property with a string of length > 2', () => {
-    expect(response.body.text).to.be.a.string;
-    expect(response.body.text).to.have.length.greaterThan(2);
+  it('Should contain text property with a string of length > 20', () => {
+    expect(response.body.generations[0].text).to.have.length.greaterThan(20);
+  });
+});
+
+describe('The generate endpoint successfully completes with multiple generations', () => {
+  var response:any;
+  before(async () => {
+    response = await cohere.generate("baseline-shrimp", {
+      prompt: "hello what is your name",
+      max_tokens: 20,
+      temperature: 1,
+      k: 5,
+      num_generations: 2,
+      p: 1
+    });
+  });
+  it('Should contain a body property that contains a generations array of length two', () => {
+    expect(response).to.have.property('body');
+    expect(response.body).to.have.property('generations');
+    expect(response.body.generations).to.have.lengthOf(2);
   });
 });

--- a/test/generate.ts
+++ b/test/generate.ts
@@ -28,7 +28,7 @@ describe('The generate endpoint successfully completes', () => {
       max_tokens: 20,
       temperature: 1,
       k: 5,
-      p: 1
+      p: 1,
     });
   });
   it('Should should have a statusCode of 200', () => {

--- a/test/likelihood.ts
+++ b/test/likelihood.ts
@@ -7,7 +7,7 @@ describe('The likelihood endpoint', () => {
   var response: any;
   cohere.init(KEY);
   before(async () => {
-    response = await cohere.likelihood("large", {
+    response = await cohere.likelihood("small", {
       text: "So I crept up the basement stairs and BOOOO!",
     });
   });

--- a/test/likelihood.ts
+++ b/test/likelihood.ts
@@ -8,7 +8,7 @@ describe('The likelihood endpoint', () => {
   cohere.init(KEY);
   before(async () => {
     response = await cohere.likelihood("baseline-shrimp", {
-      text: "So I crept up the basement stairs and BOOOO!"
+      text: "So I crept up the basement stairs and BOOOO!",
     });
   });
   it('Should should have a statusCode of 200', () => {

--- a/test/similarity.ts
+++ b/test/similarity.ts
@@ -8,7 +8,7 @@ describe('The similarity endpoint', () => {
   cohere.init(KEY);
   const targets = ["greeting", "request for assistance"];
   before(async () => {
-    response = await cohere.similarity("large", {
+    response = await cohere.similarity("small", {
       anchor: "Hi how are you doing today?",
       targets,
     });

--- a/test/similarity.ts
+++ b/test/similarity.ts
@@ -10,7 +10,7 @@ describe('The similarity endpoint', () => {
   before(async () => {
     response = await cohere.similarity("baseline-shrimp", {
       anchor: "Hi how are you doing today?",
-      targets
+      targets,
     });
   });
   it('Should should have a statusCode of 200', () => {


### PR DESCRIPTION
We shouldn't duplicate client error handling that is done on the server, both for maintenance cost/cleanliness and it could be helpful for analytics! 

made these along the way; https://github.com/cohere-ai/cohere-node/issues/13, https://github.com/cohere-ai/cohere-node/issues/12, https://github.com/cohere-ai/cohere-node/issues/15, #16