### PR TITLE
fix the length of the content being sent with http requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohere-ai",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A Node.js SDK with TypeScript support for the Cohere API.",
   "homepage": "https://docs.cohere.ai",
   "main": "index.js",

--- a/services/api_service.ts
+++ b/services/api_service.ts
@@ -13,7 +13,7 @@ enum URL {
 
 class APIImpl implements APIService {
   private COHERE_API_KEY = '';
-  private COHERE_VERSION = ''; 
+  private COHERE_VERSION = '';
 
   public init(key: string, version?: string): void {
     this.COHERE_API_KEY = key;
@@ -32,14 +32,13 @@ class APIImpl implements APIService {
         data = JSON.parse(`${data}`);
       } catch(e){}
       const reqData = JSON.stringify(data);
-
       const req = https.request({
         hostname: URL.COHERE_API,
         path: endpoint,
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': reqData.length,
+          'Content-Type': 'application/json; charset=utf-8',
+          'Content-Length': Buffer.byteLength(reqData, 'utf8'),
           'Cohere-Version': this.COHERE_VERSION,
           'Authorization': `Bearer ${this.COHERE_API_KEY}`,
           'Request-Source': 'node-sdk',
@@ -57,7 +56,8 @@ class APIImpl implements APIService {
 
       req.on('error', (error: Record<string, unknown>) => reject(errors.handleError(error)));
 
-      req.write(reqData);
+      req.write(reqData, 'utf8');
+      req.end();
     })
   }
 }

--- a/test/generate.ts
+++ b/test/generate.ts
@@ -24,7 +24,7 @@ describe('The generate endpoint successfully completes', () => {
   var response:any;
   before(async () => {
     response = await cohere.generate("small", {
-      prompt: "hello what is your name",
+      prompt: "hello what is your name. £ symbols sometimes cause problems.",
       max_tokens: 20,
       temperature: 1,
       k: 5,

--- a/test/test.ts
+++ b/test/test.ts
@@ -6,6 +6,6 @@ function importTest(name: string, path: string) {
 
 describe('The `small` model', () => {
   importTest("generate", "./generate.ts")
-  // importTest("choose-best", "./choose-best.ts")
-  // importTest("embed", "./embed.ts")
+  importTest("choose-best", "./choose-best.ts")
+  importTest("embed", "./embed.ts")
 });

--- a/test/test.ts
+++ b/test/test.ts
@@ -6,6 +6,6 @@ function importTest(name: string, path: string) {
 
 describe('The `small` model', () => {
   importTest("generate", "./generate.ts")
-  importTest("choose-best", "./choose-best.ts")
-  importTest("embed", "./embed.ts")
+  // importTest("choose-best", "./choose-best.ts")
+  // importTest("embed", "./embed.ts")
 });


### PR DESCRIPTION
Resolves #25. 

Looks like the content length of the string was not correctly matching with utf-8 encodings when special characters were involved. 

I set a slightly stricter utf-8 encoding to the `Content-Type`, `req.write()` and use `Buffer.byteLength` for length rather than just javascripts `length`

Should work with characters like `€` now. 

