### PR TITLE
Extract endpoint working in prod + tests!

### DIFF
--- a/cohere.ts
+++ b/cohere.ts
@@ -6,6 +6,7 @@ enum ENDPOINT {
   EMBED = '/embed',
   CHOOSE_BEST = '/choose-best',
   CLASSIFY = '/classify',
+  EXTRACT = '/extract',
 }
 
 const COHERE_EMBED_BATCH_SIZE = 5;
@@ -24,6 +25,10 @@ interface CohereService {
     model: string,
     config: models.chooseBest
   ): Promise<models.cohereResponse<models.scores>>;
+  extract(
+    model: string, 
+    config: models.extract
+    ): Promise<models.cohereResponse<models.extraction[]>>;
 }
 
 class Cohere implements CohereService {
@@ -122,6 +127,13 @@ class Cohere implements CohereService {
       models.cohereResponse<models.classifications>
     >;
   }
+
+  /**
+   * Extract text from texts, with examples
+   */
+  public extract(model: string, config: models.extract): Promise<models.cohereResponse<models.extraction[]>> {
+    return this.makeRequest(model, ENDPOINT.EXTRACT, config) as Promise<models.cohereResponse<models.extraction[]>>;
+  } 
 }
 const cohere = new Cohere();
 export = cohere;

--- a/models/index.ts
+++ b/models/index.ts
@@ -72,7 +72,7 @@ export interface classify {
   taskDescription?: string;
 }
 
-export type cohereParameters = generate | embed | chooseBest | classify;
+export type cohereParameters = generate | embed | chooseBest | classify | extract;
 
 /* -- responses -- */
 export interface text {
@@ -135,6 +135,26 @@ export interface classifications {
     /** The confidence score for each option. */
     confidences: { option: string; confidence: number }[];
   }[];
+}
+
+
+export interface extraction {
+  id: string;
+  text: string;
+  entities: extractEntity[];
+}
+
+export interface extractEntity {
+  type: string;
+  value: string;
+}
+export interface extractExample {
+  text: string;
+  entities: extractEntity[];
+}
+export interface extract {
+  examples: extractExample[];
+  texts: string[];
 }
 
 export interface error {

--- a/test/extract.ts
+++ b/test/extract.ts
@@ -1,0 +1,111 @@
+import { expect } from 'chai';
+import { extract, extractEntity, extraction } from '../models/index';
+import cohere = require('../index');
+require('dotenv').config({ path: '.env.test' })
+const KEY: string = process.env.API_KEY || '';
+
+describe('The extract endpoint', () => {
+    var response: any;
+    cohere.init(KEY);
+    before(async () => {
+        response = await cohere.extract("small", {
+            examples: [{
+                text: "hello my name is John, and I like to play ping pong",
+                entities: [
+                    { type: "Name", value: "John" }
+                ],
+            }],
+            texts: ["hello Roberta, how are you doing today?"]
+        });
+    });
+    it('Should should have a statusCode of 200', () => {
+        expect(response).to.have.property('statusCode');
+        expect(response.statusCode).to.equal(200);
+    });
+    it('Should contain the correct properties', () => {
+        expect(response).to.have.property('body');
+        expect(response.body).to.have.property('results');
+        expect(response.body.results).to.be.a('array')
+    });
+    //this is a quality/formatting check more than anything
+    it('Should contain the name extracted', () => {
+        expect(response.body.results.length).to.above(0);
+        const firstExtraction: extraction = response.body.results[0];
+        const entity: extractEntity = firstExtraction.entities[0];
+        expect(entity.type).to.equal("Name");
+        expect(entity.value).to.equal("Roberta");
+    });
+});
+
+describe('The extract endpoint', () => {
+    var response: any;
+    cohere.init(KEY);
+    before(async () => {
+        response = await cohere.extract("small", {
+            examples: [],
+            texts: ["hello Roberta, how are you doing today?"]
+        });
+    });
+    it('Should should fail when no text are given', () => {
+        expect(response).to.have.property('statusCode');
+        expect(response.statusCode).to.equal(400);
+    });
+});
+
+describe('The extract endpoint', () => {
+    var response: any;
+    cohere.init(KEY);
+    before(async () => {
+        response = await cohere.extract("small", {
+            examples: [{
+                text: "",
+                entities: [
+                    { type: "Name", value: "John" }
+                ],
+            }],
+            texts: ["hello Roberta, how are you doing today?"]
+        });
+    });
+    it('Should should fail when no text is given in examples', () => {
+        expect(response).to.have.property('statusCode');
+        expect(response.statusCode).to.equal(400);
+    });
+});
+
+describe('The extract endpoint', () => {
+    var response: any;
+    cohere.init(KEY);
+    before(async () => {
+        response = await cohere.extract("small", {
+            examples: [{
+                text: "hello my name is John, and I like to play ping pong",
+                entities: []
+            }],
+            texts: ["hello Roberta, how are you doing today?"]
+        });
+    });
+    it('Should should fail when no entities are given in examples', () => {
+        expect(response).to.have.property('statusCode');
+        expect(response.statusCode).to.equal(400);
+    });
+});
+
+describe('The extract endpoint', () => {
+    var response: any;
+    cohere.init(KEY);
+    before(async () => {
+        response = await cohere.extract("small", {
+            examples: [{
+                text: "hello my name is John, and I like to play ping pong",
+                entities: [
+                    { type: "Name", value: "John" }
+                ],
+            }],
+            texts: [""]
+        });
+    });
+    it('Should should fail when no text is given', () => {
+        expect(response).to.have.property('statusCode');
+        expect(response.statusCode).to.equal(400);
+    });
+});

--- a/test/test.ts
+++ b/test/test.ts
@@ -9,4 +9,5 @@ describe('The `small` model', () => {
   importTest('choose-best', './choose-best.ts');
   importTest('embed', './embed.ts');
   importTest('classify', './classify.ts');
+  importTest("extract", "./extract.ts");
 });


### PR DESCRIPTION
Followed current set conventions in the repo.
Not super happy with overall naming of request objects/ and responses but this can be handled at a later date.