### PR TITLE
Update classify endpoint response values

### DIFF
--- a/cohere.ts
+++ b/cohere.ts
@@ -26,9 +26,9 @@ interface CohereService {
     config: models.chooseBest
   ): Promise<models.cohereResponse<models.scores>>;
   extract(
-    model: string, 
+    model: string,
     config: models.extract
-    ): Promise<models.cohereResponse<models.extraction[]>>;
+  ): Promise<models.cohereResponse<models.extraction[]>>;
 }
 
 class Cohere implements CohereService {
@@ -117,7 +117,8 @@ class Cohere implements CohereService {
   }
 
   /**
-   * Classifies text as one of the given labels. Returns a confidence score for each label.
+   * Classifies text as one of the given labels. Returns a confidence score for each label.\
+   * See: https://docs.cohere.ai/classify-reference
    */
   public classify(
     model: string,
@@ -131,9 +132,14 @@ class Cohere implements CohereService {
   /**
    * Extract text from texts, with examples
    */
-  public extract(model: string, config: models.extract): Promise<models.cohereResponse<models.extraction[]>> {
-    return this.makeRequest(model, ENDPOINT.EXTRACT, config) as Promise<models.cohereResponse<models.extraction[]>>;
-  } 
+  public extract(
+    model: string,
+    config: models.extract
+  ): Promise<models.cohereResponse<models.extraction[]>> {
+    return this.makeRequest(model, ENDPOINT.EXTRACT, config) as Promise<
+      models.cohereResponse<models.extraction[]>
+    >;
+  }
 }
 const cohere = new Cohere();
 export = cohere;

--- a/models/index.ts
+++ b/models/index.ts
@@ -72,7 +72,12 @@ export interface classify {
   taskDescription?: string;
 }
 
-export type cohereParameters = generate | embed | chooseBest | classify | extract;
+export type cohereParameters =
+  | generate
+  | embed
+  | chooseBest
+  | classify
+  | extract;
 
 /* -- responses -- */
 export interface text {
@@ -133,10 +138,9 @@ export interface classifications {
     /** The predicted label for the input. */
     prediction: string;
     /** The confidence score for each option. */
-    confidences: { option: string; confidence: number }[];
+    confidences: { label: string; value: number }[];
   }[];
 }
-
 
 export interface extraction {
   id: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cohere-ai",
-  "version": "2.3.0",
+  "version": "3.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cohere-ai",
-      "version": "2.3.0",
+      "version": "3.2.1",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.2.18",
@@ -1196,6 +1196,7 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohere-ai",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "A Node.js SDK with TypeScript support for the Cohere API.",
   "homepage": "https://docs.cohere.ai",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohere-ai",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A Node.js SDK with TypeScript support for the Cohere API.",
   "homepage": "https://docs.cohere.ai",
   "main": "index.js",

--- a/test/classify.ts
+++ b/test/classify.ts
@@ -8,7 +8,7 @@ describe('The classify endpoint', () => {
   cohere.init(KEY);
 
   it('Should should have a statusCode of 200', async () => {
-    response = await cohere.classify('medium', {
+    response = await cohere.classify('small', {
       examples: [
         { text: 'apple', label: 'food' },
         { text: 'pizza', label: 'food' },
@@ -23,7 +23,7 @@ describe('The classify endpoint', () => {
     expect(response.statusCode).to.equal(200);
   });
   it('Should contain a body property that contains a classifications property', async () => {
-    response = await cohere.classify('medium', {
+    response = await cohere.classify('small', {
       examples: [
         { text: 'apple', label: 'food' },
         { text: 'pizza', label: 'food' },
@@ -36,8 +36,8 @@ describe('The classify endpoint', () => {
     expect(response).to.have.property('body');
     expect(response.body.classifications).to.be.an('array');
   });
-  it('Should contain prediciton for food and color', async () => {
-    response = await cohere.classify('medium', {
+  it('Should contain prediction for food and color', async () => {
+    response = await cohere.classify('small', {
       examples: [
         { text: 'apple', label: 'food' },
         { text: 'pizza', label: 'food' },
@@ -56,10 +56,10 @@ describe('The classify endpoint', () => {
     expect(response.body.classifications[0].prediction).to.equal('color'); // pink
     expect(response.body.classifications[1].prediction).to.equal('food'); // egg
     expect(response.body.classifications[2].prediction).to.equal('food'); // pasta
-  });
+  }).timeout(6000);
 
   it('Should contain confidences', async () => {
-    response = await cohere.classify('medium', {
+    response = await cohere.classify('small', {
       examples: [
         { text: 'apple', label: 'food' },
         { text: 'pizza', label: 'food' },
@@ -76,15 +76,15 @@ describe('The classify endpoint', () => {
     });
     expect(response.body.classifications[0].confidences).to.be.an('array');
     expect(response.body.classifications[0].confidences[0]).to.have.property(
-      'option'
+      'label'
     );
     expect(response.body.classifications[0].confidences[0]).to.have.property(
-      'confidence'
+      'value'
     );
-  });
+  }).timeout(6000);
 
   it('Should classify for all params', async () => {
-    response = await cohere.classify('medium', {
+    response = await cohere.classify('small', {
       taskDescription: 'Classify these words as either a color or a food.',
       examples: [
         { text: 'apple', label: 'food' },
@@ -104,5 +104,5 @@ describe('The classify endpoint', () => {
     expect(response.body.classifications[0].prediction).to.equal('color'); // blue
     expect(response.body.classifications[1].prediction).to.equal('food'); // hamburger
     expect(response.body.classifications[2].prediction).to.equal('food'); // pasta
-  });
+  }).timeout(6000);
 });


### PR DESCRIPTION
The following fields in the Classify response are being updated:
`option` -> `label`
`confidence` -> `value`

New response:
```
{
  classifications: {
    /** The input that is being classified. */
    input: string;
    /** The predicted label for the input. */
    prediction: string;
    /** The confidence score for each option. */
    confidences: { label: string; value: number }[];
  }[]
}
```