### PR TITLE
Add language param to the Generate API

### DIFF
--- a/models/index.ts
+++ b/models/index.ts
@@ -41,6 +41,8 @@ export interface generate {
    * text.
    */
   return_likelihoods?: 'GENERATION' | 'ALL' | 'NONE';
+  /** One of en|pt|sp|fr|de to specify the language of the prompt. By default, the language is English. */
+  language?: 'en' | 'pt' | 'sp' | 'fr' | 'de';
 }
 
 export interface embed {

--- a/test/generate.ts
+++ b/test/generate.ts
@@ -27,6 +27,7 @@ describe('The generate endpoint successfully completes', () => {
       prompt: "hello what is your name. £ symbols sometimes cause problems.",
       max_tokens: 20,
       temperature: 1,
+      language: "en",
       k: 5,
       p: 1,
     });


### PR DESCRIPTION
As part of https://github.com/cohere-ai/blobheart/pull/3680 the Generate API now accepts a "language" parameter. This PR updates the SDK to accept "language" as an argument and include it int the API request.

