### PR TITLE
Change model param to use body instead of url

### DIFF
--- a/cohere.ts
+++ b/cohere.ts
@@ -13,15 +13,12 @@ const COHERE_EMBED_BATCH_SIZE = 5;
 interface CohereService {
   init(key: string, version?: string): void;
   generate(
-    model: string,
     config: models.generate
   ): Promise<models.cohereResponse<models.text>>;
   embed(
-    model: string,
     config: models.embed
   ): Promise<models.cohereResponse<models.embeddings>>;
   extract(
-    model: string, 
     config: models.extract
     ): Promise<models.cohereResponse<models.extraction[]>>;
 }
@@ -32,21 +29,19 @@ class Cohere implements CohereService {
   }
 
   private makeRequest(
-    model: string,
     endpoint: string,
     data: models.cohereParameters
   ): Promise<models.cohereResponse<models.responseBody>> {
-    return API.post(`/${model}${endpoint}`, data);
+    return API.post(endpoint, data);
   }
 
   /** Generates realistic text conditioned on a given input.
    * See: https://docs.cohere.ai/generate-reference
    */
   public generate(
-    model: string,
     config: models.generate
   ): Promise<models.cohereResponse<models.text>> {
-    return this.makeRequest(model, ENDPOINT.GENERATE, config) as Promise<
+    return this.makeRequest(ENDPOINT.GENERATE, config) as Promise<
       models.cohereResponse<models.text>
     >;
   }
@@ -56,7 +51,6 @@ class Cohere implements CohereService {
    * See: https://docs.cohere.ai/embed-reference
    */
   public embed(
-    model: string,
     config: models.embed
   ): Promise<models.cohereResponse<models.embeddings>> {
     const createBatches = (array: string[]) => {
@@ -75,7 +69,7 @@ class Cohere implements CohereService {
     return Promise.all(
       createBatches(config.texts).map(
         (texts) =>
-          this.makeRequest(model, ENDPOINT.EMBED, {
+          this.makeRequest(ENDPOINT.EMBED, {
             ...config,
             texts,
           }) as Promise<models.cohereResponse<models.embeddings>>
@@ -99,10 +93,9 @@ class Cohere implements CohereService {
    * Classifies text as one of the given labels. Returns a confidence score for each label.
    */
   public classify(
-    model: string,
     config: models.classify
   ): Promise<models.cohereResponse<models.classifications>> {
-    return this.makeRequest(model, ENDPOINT.CLASSIFY, config) as Promise<
+    return this.makeRequest(ENDPOINT.CLASSIFY, config) as Promise<
       models.cohereResponse<models.classifications>
     >;
   }
@@ -110,8 +103,8 @@ class Cohere implements CohereService {
   /**
    * Extract text from texts, with examples
    */
-  public extract(model: string, config: models.extract): Promise<models.cohereResponse<models.extraction[]>> {
-    return this.makeRequest(model, ENDPOINT.EXTRACT, config) as Promise<models.cohereResponse<models.extraction[]>>;
+  public extract(config: models.extract): Promise<models.cohereResponse<models.extraction[]>> {
+    return this.makeRequest(ENDPOINT.EXTRACT, config) as Promise<models.cohereResponse<models.extraction[]>>;
   } 
 }
 const cohere = new Cohere();

--- a/models/index.ts
+++ b/models/index.ts
@@ -5,6 +5,8 @@ export interface cohereResponse<T> {
 
 /*-- function parameters --*/
 export interface generate {
+  /** Denotes the model to be used. Defaults to the best performing model */
+  model?: string;
   /** Represents the prompt or text to be completed. */
   prompt: string;
   /** Denotes the number of tokens to predict per generation. */
@@ -44,6 +46,8 @@ export interface generate {
 }
 
 export interface embed {
+  /** Denotes the model to be used. Defaults to the best performing model */
+  model?: string;
   /** An array of strings for the model to embed. */
   texts: string[];
   /** Specifies how the API will handle inputs longer than the maximum token length. */
@@ -51,6 +55,8 @@ export interface embed {
 }
 
 export interface classify {
+  /** Denotes the model to be used. Defaults to the best performing model */
+  model?: string;
   /** An array of strings that you would like to classify. */
   inputs: string[];
   /** An array of examples representing examples and the corresponding label. */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohere-ai",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "description": "A Node.js SDK with TypeScript support for the Cohere API.",
   "homepage": "https://docs.cohere.ai",
   "main": "index.js",

--- a/test/classify.ts
+++ b/test/classify.ts
@@ -8,7 +8,8 @@ describe('The classify endpoint', () => {
   cohere.init(KEY);
 
   it('Should should have a statusCode of 200', async () => {
-    response = await cohere.classify('medium', {
+    response = await cohere.classify({
+      model: 'small',
       examples: [
         { text: 'apple', label: 'food' },
         { text: 'pizza', label: 'food' },
@@ -23,7 +24,8 @@ describe('The classify endpoint', () => {
     expect(response.statusCode).to.equal(200);
   });
   it('Should contain a body property that contains a classifications property', async () => {
-    response = await cohere.classify('medium', {
+    response = await cohere.classify({
+      model: 'small',
       examples: [
         { text: 'apple', label: 'food' },
         { text: 'pizza', label: 'food' },
@@ -37,7 +39,8 @@ describe('The classify endpoint', () => {
     expect(response.body.classifications).to.be.an('array');
   });
   it('Should contain prediciton for food and color', async () => {
-    response = await cohere.classify('medium', {
+    response = await cohere.classify({
+      model: 'small',
       examples: [
         { text: 'apple', label: 'food' },
         { text: 'pizza', label: 'food' },
@@ -59,7 +62,8 @@ describe('The classify endpoint', () => {
   });
 
   it('Should contain confidences', async () => {
-    response = await cohere.classify('medium', {
+    response = await cohere.classify({
+      model: 'small',
       examples: [
         { text: 'apple', label: 'food' },
         { text: 'pizza', label: 'food' },
@@ -84,7 +88,8 @@ describe('The classify endpoint', () => {
   });
 
   it('Should classify for all params', async () => {
-    response = await cohere.classify('medium', {
+    response = await cohere.classify({
+      model: 'small',
       taskDescription: 'Classify these words as either a color or a food.',
       examples: [
         { text: 'apple', label: 'food' },

--- a/test/embed.ts
+++ b/test/embed.ts
@@ -20,7 +20,7 @@ describe('The embed endpoint', () => {
     'nets',
   ];
   before(async () => {
-    response = await cohere.embed('small', {
+    response = await cohere.embed({
       texts: texts,
       truncate: 'NONE',
     });

--- a/test/extract.ts
+++ b/test/extract.ts
@@ -8,7 +8,7 @@ describe('The extract endpoint', () => {
     var response: any;
     cohere.init(KEY);
     before(async () => {
-        response = await cohere.extract("small", {
+        response = await cohere.extract({
             examples: [{
                 text: "hello my name is John, and I like to play ping pong",
                 entities: [
@@ -41,7 +41,7 @@ describe('The extract endpoint', () => {
     var response: any;
     cohere.init(KEY);
     before(async () => {
-        response = await cohere.extract("small", {
+        response = await cohere.extract({
             examples: [],
             texts: ["hello Roberta, how are you doing today?"]
         });
@@ -56,7 +56,7 @@ describe('The extract endpoint', () => {
     var response: any;
     cohere.init(KEY);
     before(async () => {
-        response = await cohere.extract("small", {
+        response = await cohere.extract({
             examples: [{
                 text: "",
                 entities: [
@@ -76,7 +76,7 @@ describe('The extract endpoint', () => {
     var response: any;
     cohere.init(KEY);
     before(async () => {
-        response = await cohere.extract("small", {
+        response = await cohere.extract({
             examples: [{
                 text: "hello my name is John, and I like to play ping pong",
                 entities: []
@@ -94,7 +94,7 @@ describe('The extract endpoint', () => {
     var response: any;
     cohere.init(KEY);
     before(async () => {
-        response = await cohere.extract("small", {
+        response = await cohere.extract({
             examples: [{
                 text: "hello my name is John, and I like to play ping pong",
                 entities: [

--- a/test/generate.ts
+++ b/test/generate.ts
@@ -23,7 +23,8 @@ cohere.init(KEY);
 describe('The generate endpoint successfully completes', () => {
   var response:any;
   before(async () => {
-    response = await cohere.generate("small", {
+    response = await cohere.generate({
+      model: 'small',
       prompt: "hello what is your name. £ symbols sometimes cause problems.",
       max_tokens: 20,
       temperature: 1,
@@ -49,7 +50,8 @@ describe('The generate endpoint successfully completes', () => {
 describe('The generate endpoint successfully completes with multiple generations', () => {
   var response:any;
   before(async () => {
-    response = await cohere.generate("small", {
+    response = await cohere.generate({
+      model: 'small',
       prompt: "hello what is your name",
       max_tokens: 20,
       temperature: 1,
@@ -68,7 +70,8 @@ describe('The generate endpoint successfully completes with multiple generations
 describe('The generate endpoint with generation return likelihoods successfully returns a likelihood', () => {
   var response:any;
   before(async () => {
-    response = await cohere.generate("small", {
+    response = await cohere.generate({
+      model: 'small',
       prompt: "hello what is your name",
       max_tokens: 20,
       temperature: 1,
@@ -85,7 +88,8 @@ describe('The generate endpoint with generation return likelihoods successfully 
 describe('The generate endpoint with all return likelihoods successfully returns a likelihood', () => {
   var response:any;
   before(async () => {
-    response = await cohere.generate("small", {
+    response = await cohere.generate({
+      model: 'small',
       prompt: "hello what is your name",
       max_tokens: 20,
       temperature: 1,
@@ -102,7 +106,8 @@ describe('The generate endpoint with all return likelihoods successfully returns
 describe('The generate endpoint with no return likelihoods does not return a likelihood', () => {
   var response:any;
   before(async () => {
-    response = await cohere.generate("small", {
+    response = await cohere.generate({
+      model: 'small',
       prompt: "hello what is your name",
       max_tokens: 20,
       temperature: 1,


### PR DESCRIPTION
As a part of https://github.com/cohere-ai/blobheart/issues/3963 all endpoints will now take model as an optional param in the body instead of the URL. The old URL model will still be supported but will eventually be deprecated.