### PR TITLE
Update classify params to use correct casing

### DIFF
--- a/models/index.ts
+++ b/models/index.ts
@@ -62,9 +62,9 @@ export interface classify {
   /** An array of examples representing examples and the corresponding label. */
   examples: { text: string; label: string }[];
   /** An optional string to append onto every example and text prior to the label. */
-  outputIndicator?: string;
+  output_indicator?: string;
   /** An optional string representing what you'd like the model to do. */
-  taskDescription?: string;
+  task_description?: string;
 }
 
 export type cohereParameters = generate | embed | classify | extract;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohere-ai",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "A Node.js SDK with TypeScript support for the Cohere API.",
   "homepage": "https://docs.cohere.ai",
   "main": "index.js",

--- a/test/classify.ts
+++ b/test/classify.ts
@@ -90,7 +90,7 @@ describe('The classify endpoint', () => {
   it('Should classify for all params', async () => {
     response = await cohere.classify({
       model: 'small',
-      taskDescription: 'Classify these words as either a color or a food.',
+      task_description: 'Classify these words as either a color or a food.',
       examples: [
         { text: 'apple', label: 'food' },
         { text: 'pizza', label: 'food' },
@@ -104,7 +104,7 @@ describe('The classify endpoint', () => {
         { text: 'white', label: 'color' },
       ],
       inputs: ['blue', 'hamburger', 'pasta'],
-      outputIndicator: 'This is',
+      output_indicator: 'This is',
     });
     expect(response.body.classifications[0].prediction).to.equal('color'); // blue
     expect(response.body.classifications[1].prediction).to.equal('food'); // hamburger


### PR DESCRIPTION
the Classify parameters `taskDescription` and `outputIndicator` are being replaced with `task_description` and `output_indicator` respectively to be consistent with the casing of other parameters.

This PR updates the SDK to use these new params.