### PR TITLE
Add tokenize endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Cohere Endpoint | Function
 ----- | -----
 /generate  | cohere.generate()
 /embed | cohere.embed()
+/classify | cohere.classify()
+/tokenize | cohere.tokenize()
 
 ## Models
 To view an up to date list of available models please consult the [Cohere CLI](https://docs.cohere.ai/command/). To get started try out `large`.

--- a/cohere.ts
+++ b/cohere.ts
@@ -6,6 +6,7 @@ enum ENDPOINT {
   EMBED = '/embed',
   CLASSIFY = '/classify',
   EXTRACT = '/extract',
+  TOKENIZE = '/tokenize',
 }
 
 const COHERE_EMBED_BATCH_SIZE = 5;
@@ -44,6 +45,12 @@ class Cohere implements CohereService {
     return this.makeRequest(ENDPOINT.GENERATE, config) as Promise<
       models.cohereResponse<models.text>
     >;
+  }
+
+  public tokenize({ text }: models.tokenize): Promise<models.cohereResponse<models.tokens>> {
+    return this.makeRequest(ENDPOINT.TOKENIZE, {
+      text,
+    }) as Promise<models.cohereResponse<models.tokens>>;
   }
 
   /** Returns text embeddings. An embedding is a list of floating point numbers that captures semantic

--- a/models/index.ts
+++ b/models/index.ts
@@ -93,6 +93,7 @@ export interface text {
 }
 
 export interface tokens {
+  /** An array of integers, representing the token ids for the specified text. */
   tokens: number[];
 }
 

--- a/models/index.ts
+++ b/models/index.ts
@@ -42,7 +42,7 @@ export interface generate {
    * text. If ALL is selected, the token likelihoods will be provided both for the prompt and the generated
    * text.
    */
-  return_likelihoods?: 'GENERATION' | 'ALL' | 'NONE';
+  return_likelihoods?: "GENERATION" | "ALL" | "NONE";
 }
 
 export interface embed {
@@ -51,7 +51,7 @@ export interface embed {
   /** An array of strings for the model to embed. */
   texts: string[];
   /** Specifies how the API will handle inputs longer than the maximum token length. */
-  truncate?: 'NONE' | 'LEFT' | 'RIGHT';
+  truncate?: "NONE" | "LEFT" | "RIGHT";
 }
 
 export interface classify {
@@ -67,7 +67,12 @@ export interface classify {
   taskDescription?: string;
 }
 
-export type cohereParameters = generate | embed | classify | extract;
+export interface tokenize {
+  /** The text to be tokenized */
+  text: string;
+}
+
+export type cohereParameters = generate | embed | classify | extract | tokenize;
 
 /* -- responses -- */
 export interface text {
@@ -85,6 +90,10 @@ export interface text {
     likelihood?: number;
   };
   [key: string]: any;
+}
+
+export interface tokens {
+  tokens: number[];
 }
 
 export interface embeddings {
@@ -132,7 +141,6 @@ export interface classifications {
   }[];
 }
 
-
 export interface extraction {
   id: string;
   text: string;
@@ -143,10 +151,12 @@ export interface extractEntity {
   type: string;
   value: string;
 }
+
 export interface extractExample {
   text: string;
   entities: extractEntity[];
 }
+
 export interface extract {
   examples: extractExample[];
   texts: string[];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cohere-ai",
-  "version": "2.3.0",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cohere-ai",
-      "version": "2.3.0",
+      "version": "4.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.2.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohere-ai",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "A Node.js SDK with TypeScript support for the Cohere API.",
   "homepage": "https://docs.cohere.ai",
   "main": "index.js",

--- a/test/test.ts
+++ b/test/test.ts
@@ -9,4 +9,5 @@ describe('The `small` model', () => {
   importTest('embed', './embed.ts');
   importTest('classify', './classify.ts');
   importTest("extract", "./extract.ts");
+  importTest("tokenize", "./tokenize.ts");
 });

--- a/test/tokenize.ts
+++ b/test/tokenize.ts
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import cohere = require('../index');
+require('dotenv').config({ path: '.env.test' })
+const KEY: string = process.env.API_KEY || '';
+
+describe('The tokenize endpoint', () => {
+    var response: any;
+    cohere.init(KEY);
+    before(async () => {
+        response = await cohere.tokenize(
+            {text: "hello world"},
+        );
+    });
+    it('Should should have a statusCode of 200', () => {
+        expect(response).to.have.property('statusCode');
+        expect(response.statusCode).to.equal(200);
+    });
+    it('Should contain the correct tokens', () => {
+        expect(response).to.have.property('body');
+        expect(response.body).to.have.property('tokens');
+        expect(response.body.tokens).to.deep.equal([33555, 1114])
+    });
+});


### PR DESCRIPTION
Adds an method for converting text to tokens. Internally this makes an HTTP call to the cohere Tokenize API. More documentation: https://docs.cohere.ai/tokenize-reference/ 