### PR TITLE
Remove unused script

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,6 @@ jobs:
         run: npm run build
 
       - name: Publish
-        run: npm run publish
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "build": "webpack --env production && mv cohere.d.ts dist/cohere.d.ts && rm services/*.d.ts && rm models/*.d.ts",
     "dev": "webpack --progress --env development --env nodemon",
     "test": "mocha -r ts-node/register test/test.ts",
-    "publish": "npm run build && npm publish",
     "lint": "eslint . --ext .ts && prettier --check .",
     "lint:fix": "prettier --write ."
   },


### PR DESCRIPTION
I noticed that running `npm run publish` results in duplicate release calls. We don't actually need the "publish" script anymore, since CI is doing it via `npm publish` so removing it.