### PR TITLE
Don't fail CI if version wasn't updated

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,12 +10,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
-      - name: Configure npm registry
-        uses: actions/setup-node@v3
-        with:
-          node-version: "16.x"
-          registry-url: "https://registry.npmjs.org"
-
       - name: Install Dependencies
         run: npm ci
 
@@ -23,6 +17,6 @@ jobs:
         run: npm run build
 
       - name: Publish
-        run: npm run publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "build": "webpack --env production && mv cohere.d.ts dist/cohere.d.ts && rm services/*.d.ts && rm models/*.d.ts",
     "dev": "webpack --progress --env development --env nodemon",
     "test": "mocha -r ts-node/register test/test.ts",
-    "publish": "npm run build && npm publish",
     "lint": "eslint . --ext .ts && prettier --check .",
     "lint:fix": "prettier --write ."
   },


### PR DESCRIPTION
Currently CI fails on the main branch if a package with that version has already been published. However not all changes should result in a version bump, so instead we want to check whether the version was already published before attempting to publish.

The third-party github action JS-DevTools/npm-publish@v1 does that check for us.

<img width="430" alt="image" src="https://user-images.githubusercontent.com/1411530/186745972-09b4abd4-e90f-443a-b923-ebd2e325681c.png">
