### PR TITLE
make max_tokens param in Generate optional

### DIFF
--- a/dist/models/index.ts
+++ b/dist/models/index.ts
@@ -26,8 +26,8 @@ export interface generateRequest {
   model?: string;
   /** Represents the prompt or text to be completed. */
   prompt: string;
-  /** Denotes the number of tokens to predict per generation. */
-  max_tokens: number;
+  /** Denotes the number of tokens to predict per generation. Defaults to 20. */
+  max_tokens?: number;
   /** Denotes the maximum number of generations that will be returned. Defaults to 1, max value of 5. */
   num_generations?: number;
   /** A non-negative float that tunes the degree of randomness in generation. */

--- a/models/index.ts
+++ b/models/index.ts
@@ -26,8 +26,8 @@ export interface generateRequest {
   model?: string;
   /** Represents the prompt or text to be completed. */
   prompt: string;
-  /** Denotes the number of tokens to predict per generation. */
-  max_tokens: number;
+  /** Denotes the number of tokens to predict per generation. Defaults to 20. */
+  max_tokens?: number;
   /** Denotes the maximum number of generations that will be returned. Defaults to 1, max value of 5. */
   num_generations?: number;
   /** A non-negative float that tunes the degree of randomness in generation. */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohere-ai",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "A Node.js SDK with TypeScript support for the Cohere API.",
   "homepage": "https://docs.cohere.ai",
   "main": "index.js",


### PR DESCRIPTION
This PR makes the `max_tokens` param in Generate not required. The backend sets a default value of 20 if one is not provided.