### PR TITLE
change classify response to use labels field instead of confidences

### DIFF
--- a/dist/models/index.ts
+++ b/dist/models/index.ts
@@ -179,6 +179,8 @@ export interface classifyResponse {
     prediction: string;
     /** The confidence score for each option. */
     confidences: { option: string; confidence: number }[];
+    /** A map of predictions for each option. */
+    labels: { [label: string]: { confidence: number } };
   }[];
 }
 

--- a/models/index.ts
+++ b/models/index.ts
@@ -177,8 +177,8 @@ export interface classifyResponse {
     input: string;
     /** The predicted label for the input. */
     prediction: string;
-    /** The confidence score for each option. */
-    confidences: { option: string; confidence: number }[];
+    /** A map of predictions for each option. */
+    labels: {[label: string]: {confidence: number }};
   }[];
 }
 

--- a/models/index.ts
+++ b/models/index.ts
@@ -177,8 +177,10 @@ export interface classifyResponse {
     input: string;
     /** The predicted label for the input. */
     prediction: string;
+    /** The confidence score for each option. */
+    confidences: { option: string; confidence: number }[];
     /** A map of predictions for each option. */
-    labels: {[label: string]: {confidence: number }};
+    labels: { [label: string]: { confidence: number } };
   }[];
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohere-ai",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "A Node.js SDK with TypeScript support for the Cohere API.",
   "homepage": "https://docs.cohere.ai",
   "main": "index.js",

--- a/test/classify.ts
+++ b/test/classify.ts
@@ -62,7 +62,7 @@ describe("The classify endpoint", () => {
     expect(response.body.classifications[2].prediction).to.equal("food"); // pasta
   });
 
-  it("Should contain confidences", async () => {
+  it("Should contain labels", async () => {
     response = await cohere.classify({
       model: "small",
       examples: [
@@ -79,13 +79,9 @@ describe("The classify endpoint", () => {
       ],
       inputs: ["brown"],
     });
-    expect(response.body.classifications[0].confidences).to.be.an("array");
-    expect(response.body.classifications[0].confidences[0]).to.have.property(
-      "option"
-    );
-    expect(response.body.classifications[0].confidences[0]).to.have.property(
-      "confidence"
-    );
+    expect(response.body.classifications[0].labels).to.be.an("object")
+    expect(response.body.classifications[0].labels["color"]).to.have.property("confidence")
+    expect(Object.keys(response.body.classifications[0].labels)).to.have.length(2)
   });
 
   it("Should classify for all params", async () => {

--- a/test/classify.ts
+++ b/test/classify.ts
@@ -62,7 +62,7 @@ describe("The classify endpoint", () => {
     expect(response.body.classifications[2].prediction).to.equal("food"); // pasta
   });
 
-  it("Should contain labels", async () => {
+  it("Should contain confidences and labels", async () => {
     response = await cohere.classify({
       model: "small",
       examples: [
@@ -79,9 +79,20 @@ describe("The classify endpoint", () => {
       ],
       inputs: ["brown"],
     });
-    expect(response.body.classifications[0].labels).to.be.an("object")
-    expect(response.body.classifications[0].labels["color"]).to.have.property("confidence")
-    expect(Object.keys(response.body.classifications[0].labels)).to.have.length(2)
+    expect(response.body.classifications[0].confidences).to.be.an("array");
+    expect(response.body.classifications[0].confidences[0]).to.have.property(
+      "option"
+    );
+    expect(response.body.classifications[0].confidences[0]).to.have.property(
+      "confidence"
+    );
+    expect(response.body.classifications[0].labels).to.be.an("object");
+    expect(response.body.classifications[0].labels["color"]).to.have.property(
+      "confidence"
+    );
+    expect(Object.keys(response.body.classifications[0].labels)).to.have.length(
+      2
+    );
   });
 
   it("Should classify for all params", async () => {


### PR DESCRIPTION
Classify endpoint now returns a map of labels to their confidences. The old confidences array is being deprecated so it should get removed from the SDK.

Tests will pass once classify changes are deployed.