### PR TITLE
Remove deprecated classify params

### DIFF
--- a/dist/models/index.ts
+++ b/dist/models/index.ts
@@ -103,10 +103,6 @@ interface classifyBaseRequest {
   examples?: { text: string; label: string }[];
   /** An optional string representing the ID of a custom playground preset. */
   preset?: string;
-  /** An optional string to append onto every example and text prior to the label. */
-  outputIndicator?: string;
-  /** An optional string representing what you'd like the model to do. */
-  taskDescription?: string;
 }
 
 interface classifyWithInputsRequest extends classifyBaseRequest {

--- a/models/index.ts
+++ b/models/index.ts
@@ -103,10 +103,6 @@ interface classifyBaseRequest {
   examples?: { text: string; label: string }[];
   /** An optional string representing the ID of a custom playground preset. */
   preset?: string;
-  /** An optional string to append onto every example and text prior to the label. */
-  outputIndicator?: string;
-  /** An optional string representing what you'd like the model to do. */
-  taskDescription?: string;
 }
 
 interface classifyWithInputsRequest extends classifyBaseRequest {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cohere-ai",
-  "version": "4.1.3",
+  "version": "4.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cohere-ai",
-      "version": "4.1.3",
+      "version": "4.4.0",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.2.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohere-ai",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "description": "A Node.js SDK with TypeScript support for the Cohere API.",
   "homepage": "https://docs.cohere.ai",
   "main": "index.js",

--- a/test/classify.ts
+++ b/test/classify.ts
@@ -17,6 +17,11 @@ describe("The classify endpoint", () => {
         { text: "hamburger", label: "food" },
         { text: "taco", label: "food" },
         { text: "onion", label: "food" },
+        { text: "purple", label: "color" },
+        { text: "yellow", label: "color" },
+        { text: "red", label: "color" },
+        { text: "black", label: "color" },
+        { text: "white", label: "color" },
       ],
       inputs: ["orange"],
     });
@@ -33,6 +38,11 @@ describe("The classify endpoint", () => {
         { text: "hamburger", label: "food" },
         { text: "taco", label: "food" },
         { text: "onion", label: "food" },
+        { text: "purple", label: "color" },
+        { text: "yellow", label: "color" },
+        { text: "red", label: "color" },
+        { text: "black", label: "color" },
+        { text: "white", label: "color" },
       ],
       inputs: ["orange"],
     });
@@ -54,11 +64,11 @@ describe("The classify endpoint", () => {
         { text: "black", label: "color" },
         { text: "white", label: "color" },
       ],
-      inputs: ["pink", "egg", "pasta"],
+      inputs: ["pink", "eggplant", "pasta"],
     });
 
     expect(response.body.classifications[0].prediction).to.equal("color"); // pink
-    expect(response.body.classifications[1].prediction).to.equal("food"); // egg
+    expect(response.body.classifications[1].prediction).to.equal("food"); // eggplant
     expect(response.body.classifications[2].prediction).to.equal("food"); // pasta
   });
 
@@ -97,7 +107,7 @@ describe("The classify endpoint", () => {
 
   it("Should classify for all params", async () => {
     response = await cohere.classify({
-      model: "medium",
+      model: "small",
       examples: [
         { text: "apple", label: "food" },
         { text: "pizza", label: "food" },

--- a/test/classify.ts
+++ b/test/classify.ts
@@ -98,7 +98,6 @@ describe("The classify endpoint", () => {
   it("Should classify for all params", async () => {
     response = await cohere.classify({
       model: "small",
-      taskDescription: "Classify these words as either a color or a food.",
       examples: [
         { text: "apple", label: "food" },
         { text: "pizza", label: "food" },
@@ -112,7 +111,6 @@ describe("The classify endpoint", () => {
         { text: "white", label: "color" },
       ],
       inputs: ["blue", "hamburger", "pasta"],
-      outputIndicator: "This is",
     });
     expect(response.body.classifications[0].prediction).to.equal("color"); // blue
     expect(response.body.classifications[1].prediction).to.equal("food"); // hamburger

--- a/test/classify.ts
+++ b/test/classify.ts
@@ -97,7 +97,7 @@ describe("The classify endpoint", () => {
 
   it("Should classify for all params", async () => {
     response = await cohere.classify({
-      model: "small",
+      model: "medium",
       examples: [
         { text: "apple", label: "food" },
         { text: "pizza", label: "food" },


### PR DESCRIPTION
`outputIndicator` and `taskDescription` are no longer supported params for Classify. This change removes them from the SDK.