### PR TITLE
Add top level confidence field to Classify response

### DIFF
--- a/dist/models/index.ts
+++ b/dist/models/index.ts
@@ -158,6 +158,8 @@ export interface classifyResponse {
     input: string;
     /** The predicted label for the input. */
     prediction: string;
+    /** Confidence score for the predicted label. */
+    confidence: number;
     /** The confidence score for each option. */
     confidences: { option: string; confidence: number }[];
     /** A map of predictions for each option. */

--- a/models/index.ts
+++ b/models/index.ts
@@ -158,6 +158,8 @@ export interface classifyResponse {
     input: string;
     /** The predicted label for the input. */
     prediction: string;
+    /** Confidence score for the predicted label. */
+    confidence: number;
     /** The confidence score for each option. */
     confidences: { option: string; confidence: number }[];
     /** A map of predictions for each option. */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cohere-ai",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cohere-ai",
-      "version": "4.5.0",
+      "version": "4.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.2.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohere-ai",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "A Node.js SDK with TypeScript support for the Cohere API.",
   "homepage": "https://docs.cohere.ai",
   "main": "index.js",


### PR DESCRIPTION
The Classify API returns a top level `confidence` score, which today is not captured in the typescript ClassifyResponse interface. This PR adds it to the interface.