### PR TITLE
Remove "confidence" field from language detect endpoint

### DIFF
--- a/dist/models/index.ts
+++ b/dist/models/index.ts
@@ -180,8 +180,6 @@ export interface detectLanguageResponse {
     language_code: string;
     /** Name of the language eg. "French". */
     language_name: string;
-    /** The confidence score, a number between 0 and 1. */
-    confidence: number;
   }[];
 }
 

--- a/models/index.ts
+++ b/models/index.ts
@@ -180,8 +180,6 @@ export interface detectLanguageResponse {
     language_code: string;
     /** Name of the language eg. "French". */
     language_name: string;
-    /** The confidence score, a number between 0 and 1. */
-    confidence: number;
   }[];
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cohere-ai",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cohere-ai",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.2.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohere-ai",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "A Node.js SDK with TypeScript support for the Cohere API.",
   "homepage": "https://docs.cohere.ai",
   "main": "index.js",


### PR DESCRIPTION
We no longer want to show the confidence score of a detected language