### PR TITLE
refactor: changes summarize request from enum to union type

### DIFF
--- a/dist/models/index.ts
+++ b/dist/models/index.ts
@@ -119,22 +119,11 @@ export interface detectLanguageRequest {
   texts: string[];
 }
 
-export enum summaryLength {
-  SHORT = "SHORT",
-  MEDIUM = "MEDIUM",
-  LONG = "LONG",
-}
+export type SummaryLength = "SHORT" | "MEDIUM" | "LONG";
 
-export enum summaryFormat {
-  PARAGRAPH = "PARAGRAPH",
-  BULLET_POINTS = "BULLETS",
-}
+export type SummaryFormat = "PARAGRAPH" | "BULLETS";
 
-export enum summaryExtractiveness {
-  LOW = "LOW",
-  MEDIUM = "MEDIUM",
-  HIGH = "HIGH",
-}
+export type summaryExtractiveness = "LOW" | "MEDIUM" | "HIGH";
 
 export interface summarizeRequest {
   /** Text to summarize */
@@ -142,12 +131,12 @@ export interface summarizeRequest {
   /** Denotes the summarization model to be used. Defaults to the best performing model */
   model?: string;
   /** One of `short`, `medium` or `long`, defaults to `medium`. Indicates the approximate length of the summary.' */
-  length?: summaryLength | string;
+  length?: SummaryLength | string;
   /**  'One of `paragraph` or `bullets`, defaults to `paragraph`.
    * Indicates the style in which the summary will be delivered - in a free form
    * paragraph or in bullet points.'
    */
-  format?: summaryFormat | string;
+  format?: SummaryFormat | string;
   /** One of `low`, `medium` or `high`, defaults to `low`. Controls how close to the original text the summary is.
    * `high` extractiveness summaries will lean towards reusing sentences verbatim, while `low` extractiveness
    * summaries will tend to paraphrase more.'


### PR DESCRIPTION
# Description

I added a refactor that adds union types to co.summarize() instead of using TypeScript enums. Also noticed almost all of your codebase uses union types. Excuse me if this is an edge case where enums are good. Here's some sources behind my reasoning, but my main reason was IntelliSense :)

sources:
- https://stackoverflow.com/questions/40275832/typescript-has-unions-so-are-enums-redundant
- https://www.bam.tech/article/should-you-use-enums-or-union-types-in-typescript
- https://www.youtube.com/watch?v=jjMbPt_H3RQ (this guy is TypeScript)
## Type of change

- [x] Refactor

# How Has This Been Tested?

Passes all tests (except for the last one because my API key is rate limited haha), and now has LSP IntelliSense as well for the union types.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules